### PR TITLE
Add localized accessibility values for RadioButton and Checkbox

### DIFF
--- a/Sources/Core/Common/Extension/Foundation/Bundle+CurrentExtension.swift
+++ b/Sources/Core/Common/Extension/Foundation/Bundle+CurrentExtension.swift
@@ -1,0 +1,27 @@
+//
+//  Bundle+CurrentExtension.swift
+//  SparkComponentSelectionControls
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import Foundation
+import SparkTheming
+
+extension Bundle {
+
+    // MARK: - Class
+
+    private final class Class {}
+
+    // MARK: - Static Properties
+
+    static var current: Bundle {
+#if SWIFT_PACKAGE
+        Bundle.module
+#else
+        Bundle(for: Class.self)
+#endif
+    }
+}

--- a/Sources/Core/Common/Extension/Foundation/String+AccessibilityValueExtension.swift
+++ b/Sources/Core/Common/Extension/Foundation/String+AccessibilityValueExtension.swift
@@ -1,0 +1,22 @@
+//
+//  String+AccessibilityValueExtension.swift
+//  SparkComponentSelectionControls
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension String {
+
+    // MARK: - Methods
+
+    static func accessibilityValue(isSelected: Bool) -> String {
+        return String(
+            localized: isSelected ? "accessibility_value_selected" : "accessibility_value_not_selected",
+            bundle: .current
+        )
+    }
+}

--- a/Sources/Core/Common/Extension/SwiftUI/View+AccessibilityRemoveToggleTraits.swift
+++ b/Sources/Core/Common/Extension/SwiftUI/View+AccessibilityRemoveToggleTraits.swift
@@ -1,0 +1,22 @@
+//
+//  View+AccessibilityRemoveToggleTraits.swift
+//  SparkComponentSelectionControls
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+
+    @ViewBuilder
+    func accessibilityRemoveToggleTraits() -> some View {
+        if #available(iOS 17.0, *) {
+            self.accessibilityRemoveTraits(.isToggle)
+        } else {
+            // Fallback on earlier versions
+            self
+        }
+    }
+}

--- a/Sources/Core/Common/Resources/Localizable.xcstrings
+++ b/Sources/Core/Common/Resources/Localizable.xcstrings
@@ -1,0 +1,57 @@
+{
+  "sourceLanguage" : "fr",
+  "strings" : {
+    "accessibility_value_indeterminate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "indeterminate"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "indéterminé"
+          }
+        }
+      }
+    },
+    "accessibility_value_not_selected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "not selected"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non sélectionné"
+          }
+        }
+      }
+    },
+    "accessibility_value_selected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "selected"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sélectionné"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/Core/Components/Checkbox/Extension/Foundation/String+CheckboxAccessibilityValueExtension.swift
+++ b/Sources/Core/Components/Checkbox/Extension/Foundation/String+CheckboxAccessibilityValueExtension.swift
@@ -1,0 +1,26 @@
+//
+//  String+CheckboxAccessibilityValueExtension.swift
+//  SparkComponentSelectionControls
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension String {
+
+    // MARK: - Methods
+
+    static func accessibilityValue(selectionState: CheckboxSelectionState) -> String {
+        guard selectionState != .indeterminate else {
+            return String(
+                localized: "accessibility_value_indeterminate",
+                bundle: .current
+            )
+        }
+
+        return self.accessibilityValue(isSelected: selectionState == .selected)
+    }
+}

--- a/Sources/Core/Components/Checkbox/View/SwiftUI/SparkCheckbox.swift
+++ b/Sources/Core/Components/Checkbox/View/SwiftUI/SparkCheckbox.swift
@@ -313,6 +313,8 @@ public struct SparkCheckbox<Label>: View where Label: View {
             indeterminateIcon: self.indeterminateIcon
         ))
         .accessibilityIdentifier(CheckboxAccessibilityIdentifier.view)
+        .accessibilityRemoveToggleTraits()
+        .accessibilityValue(String.accessibilityValue(selectionState: self.selectionState))
         .onAppear() {
             self.viewModel.setup(
                 theme: self.deprecatedTheme ?? self.theme.value,

--- a/Sources/Core/Components/Checkbox/View/SwiftUI/Style/CheckboxStyle.swift
+++ b/Sources/Core/Components/Checkbox/View/SwiftUI/Style/CheckboxStyle.swift
@@ -98,6 +98,7 @@ struct CheckboxStyle: ToggleStyle {
                         minHeight: self.size
                     )
             }
+            .compositingGroup()
         }
         .buttonPressedStyle(self.$isPressed)
         .sparkSensoryFeedback(trigger: configuration.isOn)

--- a/Sources/Core/Components/Checkbox/View/UIKit/SparkUICheckbox.swift
+++ b/Sources/Core/Components/Checkbox/View/UIKit/SparkUICheckbox.swift
@@ -567,7 +567,7 @@ public final class SparkUICheckbox: UIControl {
     }
 
     private func updateAccessibilityValue() {
-        self.toggleView.accessibilityValue = self.isSelected ? "1" : "0"
+        self.toggleView.accessibilityValue = String.accessibilityValue(selectionState: self.selectionState)
     }
 
     private func updateAccessibilityEnabledTrait() {

--- a/Sources/Core/Components/RadioButton/View/SwiftUI/SparkRadioButton.swift
+++ b/Sources/Core/Components/RadioButton/View/SwiftUI/SparkRadioButton.swift
@@ -299,6 +299,8 @@ public struct SparkRadioButton<Label>: View where Label: View {
         )
         .toggleStyle(.custom(viewModel: self.viewModel))
         .accessibilityIdentifier(RadioButtonAccessibilityIdentifier.view)
+        .accessibilityRemoveToggleTraits()
+        .accessibilityValue(String.accessibilityValue(isSelected: self.isSelected))
         .onAppear() {
             self.viewModel.setup(
                 theme: self.deprecatedTheme ?? self.theme.value,

--- a/Sources/Core/Components/RadioButton/View/SwiftUI/Style/RadioButtonStyle.swift
+++ b/Sources/Core/Components/RadioButton/View/SwiftUI/Style/RadioButtonStyle.swift
@@ -71,6 +71,7 @@ struct RadioButtonStyle: ToggleStyle {
                         self.pressedView(configuration: configuration)
                     )
                 }
+                .compositingGroup()
                 .optionalAnimation(
                     .easeInOut(duration: CommonConstants.animationDuration),
                     value: self.isPressed

--- a/Sources/Core/Components/RadioButton/View/UIKit/SparkUIRadioButton.swift
+++ b/Sources/Core/Components/RadioButton/View/UIKit/SparkUIRadioButton.swift
@@ -534,7 +534,7 @@ public final class SparkUIRadioButton: UIControl {
     }
 
     private func updateAccessibilityValue() {
-        self.toggleView.accessibilityValue = self.isSelected ? "1" : "0"
+        self.toggleView.accessibilityValue = String.accessibilityValue(isSelected: self.isSelected)
     }
 
     private func updateAccessibilityEnabledTrait() {

--- a/Tests/UnitTests/Common/Extension/Foundation/String+AccessibilityValueExtensionTests.swift
+++ b/Tests/UnitTests/Common/Extension/Foundation/String+AccessibilityValueExtensionTests.swift
@@ -1,0 +1,42 @@
+//
+//  String+AccessibilityValueExtensionTests.swift
+//  SparkComponentSelectionControlsTests
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import XCTest
+@testable import SparkComponentSelectionControls
+
+final class StringAccessibilityValueExtensionTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_accessibilityValue_whenIsSelectedTrue() {
+        // GIVEN / WHEN
+        let result = String.accessibilityValue(isSelected: true)
+
+        // THEN
+        XCTAssertNotEqual(result, "accessibility_value_selected")
+        XCTAssertNotEqual(result, "accessibility_value_not_selected")
+    }
+
+    func test_accessibilityValue_whenIsSelectedFalse() {
+        // GIVEN / WHEN
+        let result = String.accessibilityValue(isSelected: false)
+
+        // THEN
+        XCTAssertNotEqual(result, "accessibility_value_selected")
+        XCTAssertNotEqual(result, "accessibility_value_not_selected")
+    }
+
+    func test_accessibilityValue_mustBeDifferent() {
+        // GIVEN / WHEN
+        let result1 = String.accessibilityValue(isSelected: true)
+        let result2 = String.accessibilityValue(isSelected: false)
+
+        // THEN
+        XCTAssertNotEqual(result1, result2)
+    }
+}

--- a/Tests/UnitTests/Components/Checkbox/Extension/Foundation/String+CheckboxAccessibilityValueExtensionTests.swift
+++ b/Tests/UnitTests/Components/Checkbox/Extension/Foundation/String+CheckboxAccessibilityValueExtensionTests.swift
@@ -1,0 +1,57 @@
+//
+//  String+CheckboxAccessibilityValueExtensionTests.swift
+//  SparkComponentSelectionControlsTests
+//
+//  Created by robin.lemaire on 27/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import XCTest
+@testable import SparkComponentSelectionControls
+
+final class StringCheckboxAccessibilityValueExtensionTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_accessibilityValue_whenSelectionStateSelected_shouldReturnSelectedString() {
+        // GIVEN / WHEN
+        let result = String.accessibilityValue(selectionState: .selected)
+
+        // THEN
+        XCTAssertNotEqual(result, "accessibility_value_selected")
+        XCTAssertNotEqual(result, "accessibility_value_not_selected")
+        XCTAssertNotEqual(result, "accessibility_value_indeterminate")
+    }
+
+    func test_accessibilityValue_whenSelectionStateUnselected_shouldReturnNotSelectedString() {
+        // GIVEN / WHEN
+        let result = String.accessibilityValue(selectionState: .unselected)
+
+        // THEN
+        XCTAssertNotEqual(result, "accessibility_value_selected")
+        XCTAssertNotEqual(result, "accessibility_value_not_selected")
+        XCTAssertNotEqual(result, "accessibility_value_indeterminate")
+    }
+
+    func test_accessibilityValue_whenSelectionStateIndeterminate_shouldReturnIndeterminateString() {
+        // GIVEN / WHEN
+        let result = String.accessibilityValue(selectionState: .indeterminate)
+
+        // THEN
+        XCTAssertNotEqual(result, "accessibility_value_selected")
+        XCTAssertNotEqual(result, "accessibility_value_not_selected")
+        XCTAssertNotEqual(result, "accessibility_value_indeterminate")
+    }
+
+    func test_accessibilityValue_mustBeDifferent() {
+        // GIVEN / WHEN
+        let result1 = String.accessibilityValue(selectionState: .selected)
+        let result2 = String.accessibilityValue(selectionState: .unselected)
+        let result3 = String.accessibilityValue(selectionState: .indeterminate)
+
+        // THEN
+        XCTAssertNotEqual(result1, result2)
+        XCTAssertNotEqual(result1, result3)
+        XCTAssertNotEqual(result2, result3)
+    }
+}


### PR DESCRIPTION
- Add three new localized strings in Localizable.xcstrings:
  - accessibility_value_selected (sélectionné / selected)
  - accessibility_value_not_selected (non sélectionné / not selected)
  - accessibility_value_indeterminate (indéterminé / indeterminate)

- Create String+AccessibilityValueExtension with methods:
  - accessibilityValue(isSelected: Bool) for RadioButton
  - accessibilityValue(selectionState: CheckboxSelectionState) for Checkbox

- Update all RadioButton and Checkbox components to use localized strings:
  - SparkRadioButton and SparkUIRadioButton
  - SparkCheckbox and SparkUICheckbox

- Add comprehensive unit tests for both extensions:
  - String+AccessibilityValueExtensionTests
  - String+CheckboxAccessibilityValueExtensionTests